### PR TITLE
render input id correctly if it is changed

### DIFF
--- a/web/form.py
+++ b/web/form.py
@@ -164,6 +164,7 @@ class Input(object):
         if self.value is not None:
             attrs['value'] = self.value
         attrs['name'] = self.name
+        attrs['id'] = self.id
         return '<input %s/>' % attrs
 
     def rendernote(self, note):


### PR DESCRIPTION
It's sometimes necessary to change a form element's ID after it's been created (e.g., when there are multiple form elements with the same name).  A bug existed that prevented the ID in the input widget from updating:

    In [1]: from web import form

    In [2]: f = form.Form(form.Textbox('x'))

    In [3]: f.render()
    Out[3]: u'<table>\n    <tr><th><label for="x">x</label></th><td><input type="text" id="x" name="x"/></td></tr>\n</table>'

    In [4]: f.x.id = 'newx'

    In [5]: f.render()
    Out[5]: u'<table>\n    <tr><th><label for="newx">x</label></th><td><input type="text" id="x" name="x"/></td></tr>\n</table>'

Note the label's ID has been updated but not the input's ID.  This fixes that bug.